### PR TITLE
remove assumptions around auth.User model

### DIFF
--- a/pinax/teams/admin.py
+++ b/pinax/teams/admin.py
@@ -4,6 +4,7 @@ from django.utils.translation import ugettext_lazy as _
 from reversion.admin import VersionAdmin
 
 from .models import Team, Membership
+from .hooks import hookset
 
 
 def members_count(obj):

--- a/pinax/teams/admin.py
+++ b/pinax/teams/admin.py
@@ -32,7 +32,7 @@ class MembershipAdmin(VersionAdmin):
     raw_id_fields = ["user"]
     list_display = ["team", "user", "state", "role"]
     list_filter = ["team"]
-    search_fields = ["user__username"]
+    search_fields = hookset.membership_search_fields
 
 
 admin.site.register(Membership, MembershipAdmin)

--- a/pinax/teams/forms.py
+++ b/pinax/teams/forms.py
@@ -63,7 +63,9 @@ class TeamInviteUserForm(forms.Form):
                 raise forms.ValidationError(MESSAGE_STRINGS["user-member-exists"])
         except User.DoesNotExist:
             try:
-                invitee = User.objects.get(username=self.cleaned_data["invitee"])
+                # search by USERNAME_FIELD
+                params = {User.USERNAME_FIELD: self.cleaned_data["invitee"]}
+                invitee = User.objects.get(**params)
                 if self.team.is_on_team(invitee):
                     raise forms.ValidationError(MESSAGE_STRINGS["user-member-exists"])
             except User.DoesNotExist:

--- a/pinax/teams/hooks.py
+++ b/pinax/teams/hooks.py
@@ -18,6 +18,11 @@ MESSAGE_STRINGS = {
 
 class TeamDefaultHookset(object):
 
+    # allows the search field in the Membership admin
+    # to be overridden if the custom user model does
+    # not have a username field
+    membership_search_fields = ["user__username"]
+
     def build_team_url(self, url_name, team_slug):
         return reverse(url_name, args=[team_slug])
 
@@ -34,6 +39,10 @@ class TeamDefaultHookset(object):
 
     def get_message_strings(self):
         return MESSAGE_STRINGS
+
+    def user_is_staff(self, user):
+        # @@@ consider staff users managers of any Team
+        return getattr(user, "is_staff", False)
 
 
 class HookProxy(object):

--- a/pinax/teams/models.py
+++ b/pinax/teams/models.py
@@ -185,6 +185,9 @@ class Team(models.Model):
             return membership.state
 
     def role_for(self, user):
+        if hookset.user_is_staff(user):
+            return Membership.ROLE_MANAGER
+
         membership = self.for_user(user)
         if membership:
             return membership.role

--- a/pinax/teams/models.py
+++ b/pinax/teams/models.py
@@ -14,6 +14,7 @@ from reversion import revisions as reversion
 from slugify import slugify
 
 from . import signals
+from .hooks import hookset
 
 
 def avatar_upload(instance, filename):


### PR DESCRIPTION
* Removes hardcoded `username` field in favor of `User.USERNAME_FIELD` and adds the ability to customize the user search field used in the admin for `Membership`
* Allows customization of a `staff`user that is considered an implicit manager of all teams on a site