### PR TITLE
fix invitee to call to_user_email method

### DIFF
--- a/pinax/teams/models.py
+++ b/pinax/teams/models.py
@@ -317,7 +317,7 @@ class Membership(models.Model):
 
     @property
     def invitee(self):
-        return self.user or self.invite.to_user_email
+        return self.user or self.invite.to_user_email()
 
     def __str__(self):
         return "{0} in {1}".format(self.user, self.team)


### PR DESCRIPTION
Calls to `membership.invitee` in a template would succeed because of how Django's template engine resolves template variables, but this change allows `membership.invitee` to work outside of templates.

[models.py in `pinax-invitations`](https://github.com/pinax/pinax-invitations/blob/6d61160a0f16e7d021e5ad416fe53dc47a80f961/pinax/invitations/models.py#L38).