### PR TITLE
Add TeamManageView and TeamInviteView CBVs

### DIFF
--- a/pinax/teams/urls.py
+++ b/pinax/teams/urls.py
@@ -14,11 +14,11 @@ urlpatterns = [
     url(r"^(?P<slug>[\w\-]+)/leave/$", views.team_leave, name="team_leave"),
     url(r"^(?P<slug>[\w\-]+)/apply/$", views.team_apply, name="team_apply"),
     url(r"^(?P<slug>[\w\-]+)/edit/$", views.team_update, name="team_edit"),
-    url(r"^(?P<slug>[\w\-]+)/manage/$", views.team_manage, name="team_manage"),
+    url(r"^(?P<slug>[\w\-]+)/manage/$", views.TeamManageView.as_view(), name="team_manage"),
 
     # membership specific
     url(r"^(?P<slug>[\w\-]+)/ac/users-to-invite/$", views.autocomplete_users, name="team_autocomplete_users"),  # noqa
-    url(r"^(?P<slug>[\w\-]+)/invite-user/$", views.team_invite, name="team_invite"),
+    url(r"^(?P<slug>[\w\-]+)/invite-user/$", views.TeamInviteView.as_view(), name="team_invite"),
     url(r"^(?P<slug>[\w\-]+)/members/(?P<pk>\d+)/revoke-invite/$", views.team_member_revoke_invite, name="team_member_revoke_invite"),  # noqa
     url(r"^(?P<slug>[\w\-]+)/members/(?P<pk>\d+)/resend-invite/$", views.team_member_resend_invite, name="team_member_resend_invite"),  # noqa
     url(r"^(?P<slug>[\w\-]+)/members/(?P<pk>\d+)/promote/$", views.team_member_promote, name="team_member_promote"),  # noqa

--- a/pinax/teams/views.py
+++ b/pinax/teams/views.py
@@ -1,12 +1,13 @@
 import json
 
-from django.http import Http404, HttpResponse, HttpResponseRedirect, HttpResponseForbidden
+from django.http import Http404, HttpResponse, HttpResponseRedirect, HttpResponseForbidden, JsonResponse
 from django.shortcuts import render, redirect, get_object_or_404
 from django.template import RequestContext
 from django.template.loader import render_to_string
+from django.utils.decorators import method_decorator
 from django.views.decorators.http import require_POST
 from django.views.generic.edit import CreateView
-from django.views.generic import ListView
+from django.views.generic import ListView, FormView, TemplateView
 
 from django.contrib import messages
 from django.contrib.auth import get_user_model
@@ -93,6 +94,32 @@ def team_detail(request):
         "can_leave": team.can_leave(request.user),
         "can_apply": team.can_apply(request.user),
     })
+
+
+class TeamManageView(TemplateView):
+
+    template_name = "teams/team_manage.html"
+
+    @method_decorator(manager_required)
+    def dispatch(self, *args, **kwargs):
+        self.team = self.request.team
+        self.role = self.team.role_for(self.request.user)
+        return super(TeamManageView, self).dispatch(*args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        ctx = super(TeamManageView, self).get_context_data(**kwargs)
+        ctx.update({
+            "team": self.team,
+            "role": self.role,
+            "invite_form": self.get_team_invite_form(),
+            "can_join": self.team.can_join(self.request.user),
+            "can_leave": self.team.can_leave(self.request.user),
+            "can_apply": self.team.can_apply(self.request.user),
+        })
+        return ctx
+
+    def get_team_invite_form(self):
+        return TeamInviteUserForm(team=self.team)
 
 
 @team_required
@@ -186,6 +213,107 @@ def team_reject(request, pk):
     if membership.reject(by=request.user):
         messages.success(request, MESSAGE_STRINGS["rejected-application"])
     return redirect("team_detail", slug=membership.team.slug)
+
+
+class TeamInviteView(FormView):
+    http_method_names = ["post"]
+    form_class = TeamInviteUserForm
+
+    @method_decorator(manager_required)
+    def dispatch(self, *args, **kwargs):
+        self.team = self.request.team
+        return super(TeamInviteView, self).dispatch(*args, **kwargs)
+
+    def get_form_kwargs(self):
+        form_kwargs = super(TeamInviteView, self).get_form_kwargs()
+        form_kwargs.update({"team": self.team})
+        return form_kwargs
+
+    def get_unbound_form(self):
+        """
+        Overrides behavior of FormView.get_form_kwargs
+        when method is POST or PUT
+        """
+        form_kwargs = self.get_form_kwargs()
+        # @@@ remove fields that would cause the form to be bound
+        # when instantiated
+        bound_fields = ["data", "files"]
+        for field in bound_fields:
+            form_kwargs.pop(field, None)
+        return self.get_form_class()(**form_kwargs)
+
+    def after_membership_added(self, form):
+        """
+        Allows the developer to customize actions that happen after a membership
+        was added in form_valid
+        """
+        pass
+
+    def get_form_success_data(self, form):
+        """
+        Allows customization of the JSON data returned when a valid form submission occurs.
+        """
+        data = {
+            "html": render_to_string(
+                "teams/_invite_form.html",
+                {
+                    "invite_form": self.get_unbound_form(),
+                    "team": self.team
+                },
+                context_instance=RequestContext(self.request)
+            )
+        }
+
+        membership = self.membership
+        if membership is not None:
+            if membership.state == Membership.STATE_APPLIED:
+                fragment_class = ".applicants"
+            elif membership.state == Membership.STATE_INVITED:
+                fragment_class = ".invitees"
+            elif membership.state in (Membership.STATE_AUTO_JOINED, Membership.STATE_ACCEPTED):
+                fragment_class = {
+                    Membership.ROLE_OWNER: ".owners",
+                    Membership.ROLE_MANAGER: ".managers",
+                    Membership.ROLE_MEMBER: ".members"
+                }[membership.role]
+            data.update({
+                "append-fragments": {
+                    fragment_class: render_to_string(
+                        "teams/_membership.html",
+                        {
+                            "membership": membership,
+                            "team": self.team
+                        },
+                        context_instance=RequestContext(self.request)
+                    )
+                }
+            })
+        return data
+
+    def form_valid(self, form):
+        user_or_email = form.cleaned_data["invitee"]
+        role = form.cleaned_data["role"]
+        if isinstance(user_or_email, string_types):
+            self.membership = self.team.invite_user(self.request.user, user_or_email, role)
+        else:
+            self.membership = self.team.add_user(user_or_email, role, by=self.request.user)
+
+        self.after_membership_added(form)
+
+        data = self.get_form_success_data(form)
+        return self.render_to_response(data)
+
+    def form_invalid(self, form):
+        data = {
+            "html": render_to_string("teams/_invite_form.html", {
+                "invite_form": form,
+                "team": self.team
+            }, context_instance=RequestContext(self.request))
+        }
+        return self.render_to_response(data)
+
+    def render_to_response(self, context, **response_kwargs):
+        return JsonResponse(context)
 
 
 @team_required


### PR DESCRIPTION
Rewrote the invite and management views as class-based views to allow further customization by the site developer.

A couple of things to highlight:

* `get_form_success_data` and `after_membership_added` can be used to tie a newly created `Membership` to other business logic on a site.
* Views use the `manager_required` decorator.  Requires #40 before this PR can land (where staff users are considered managers of all teams)
