### PR TITLE
fix Membership verbose names in model meta

### DIFF
--- a/pinax/teams/models.py
+++ b/pinax/teams/models.py
@@ -324,8 +324,8 @@ class Membership(models.Model):
 
     class Meta:
         unique_together = [("team", "user", "invite")]
-        verbose_name = _("Team")
-        verbose_name_plural = _("Teams")
+        verbose_name = _("Membership")
+        verbose_name_plural = _("Memberships")
 
 
 reversion.register(Membership)


### PR DESCRIPTION
Should refer to "Membership/s" not "Team/s"