### PR TITLE
Explicitly specify template_name for all URLs using as_view()

### DIFF
--- a/pinax/teams/urls.py
+++ b/pinax/teams/urls.py
@@ -5,8 +5,8 @@ from . import views
 
 urlpatterns = [
     # overall
-    url(r"^$", views.TeamListView.as_view(), name="team_list"),
-    url(r"^:create/$", views.TeamCreateView.as_view(), name="team_create"),
+    url(r"^$", views.TeamListView.as_view(template_name='teams/team_list.html'), name="team_list"),
+    url(r"^:create/$", views.TeamCreateView.as_view(template_name='teams/team_form.html'), name="team_create"),
 
     # team specific
     url(r"^(?P<slug>[\w\-]+)/$", views.team_detail, name="team_detail"),
@@ -14,11 +14,11 @@ urlpatterns = [
     url(r"^(?P<slug>[\w\-]+)/leave/$", views.team_leave, name="team_leave"),
     url(r"^(?P<slug>[\w\-]+)/apply/$", views.team_apply, name="team_apply"),
     url(r"^(?P<slug>[\w\-]+)/edit/$", views.team_update, name="team_edit"),
-    url(r"^(?P<slug>[\w\-]+)/manage/$", views.TeamManageView.as_view(), name="team_manage"),
+    url(r"^(?P<slug>[\w\-]+)/manage/$", views.TeamManageView.as_view(template_name='teams/team_manage.html'), name="team_manage"),
 
     # membership specific
     url(r"^(?P<slug>[\w\-]+)/ac/users-to-invite/$", views.autocomplete_users, name="team_autocomplete_users"),  # noqa
-    url(r"^(?P<slug>[\w\-]+)/invite-user/$", views.TeamInviteView.as_view(), name="team_invite"),
+    url(r"^(?P<slug>[\w\-]+)/invite-user/$", views.TeamInviteView.as_view(template_name='teams/_invite_form.html'), name="team_invite"),
     url(r"^(?P<slug>[\w\-]+)/members/(?P<pk>\d+)/revoke-invite/$", views.team_member_revoke_invite, name="team_member_revoke_invite"),  # noqa
     url(r"^(?P<slug>[\w\-]+)/members/(?P<pk>\d+)/resend-invite/$", views.team_member_resend_invite, name="team_member_resend_invite"),  # noqa
     url(r"^(?P<slug>[\w\-]+)/members/(?P<pk>\d+)/promote/$", views.team_member_promote, name="team_member_promote"),  # noqa


### PR DESCRIPTION
This makes this urls.py compatible with the project's existing views.py, where all template files are expected to be in 'teams/*'
