### PR TITLE
Use python-slugify instead of unicode-slugify

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Pinax is an open-source platform built on the Django Web Framework. It is an eco
 * pillow
 * pinax-invitations
 * six
-* unicode-slugify
+* python-slugify
 
 See [`setup.py`](https://github.com/pinax/pinax-teams/blob/master/setup.py) for specific required versions of these packages.
 
@@ -187,6 +187,10 @@ Iterable excludes teams user is already associated with.
 
 
 ## Change Log
+
+### 1.0.6
+
+* Switch to using python-slugify from unicode-slugify
 
 ### 1.0.5
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-VERSION = "1.0.5"
+VERSION = "1.0.6"
 LONG_DESCRIPTION = """
 .. image:: http://pinaxproject.com/pinax-design/patches/pinax-teams.svg
     :target: https://pypi.python.org/pypi/pinax-teams/
@@ -84,7 +84,7 @@ setup(
         "django>=1.11",
         "django-reversion>=2.0.12",
         "pinax-invitations>=6.1.2",
-        "unicode-slugify>=0.1.1",
+        "python-slugify>=3.0.4",
         "Pillow>=2.3.0",
         "django-user-accounts>=2.0.3",
         "six>=1.9.0"


### PR DESCRIPTION
The two packages have the same top level module, they do the same
thing. Only python-slugify is more powerful and more actively maintained.

By depending on unicode-slugify, we create a conflict with any package
that depends on python-slugify's extra features.