### PR TITLE
fix import of in django > 4.0 of 'ugettext_lazy'

### DIFF
--- a/pinax/teams/apps.py
+++ b/pinax/teams/apps.py
@@ -1,5 +1,10 @@
 from django.apps import AppConfig as BaseAppConfig
-from django.utils.translation import ugettext_lazy as _
+
+
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 try:
     import importlib


### PR DESCRIPTION
Closes # .

Changes proposed in this PR:

-
-

**Tips for an ideal PR**
* You have read our Code of Conduct: https://github.com/pinax/.github/blob/master/CODE_OF_CONDUCT.md
* You have read our Contributing info: https://github.com/pinax/.github/blob/master/CONTRIBUTING.md
* The PR is atomic
* Unit tests have been updated/added, if needed
* App version number has been updated in `setup.py` (Pinax uses [SemVer](https://semver.org/))
* `Change Log` has been updated
* You have added your name to the `AUTHORS` file

